### PR TITLE
fix: add missing env var warning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const inter = Inter({
@@ -19,7 +20,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.variable} antialiased`}>{children}</body>
+      <body className={`${inter.variable} antialiased`}>
+        {children}
+        <Toaster />
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { FAQs } from "@/components/faqs/faqs";
 import { Features } from "@/components/features/features";
 import { Footer } from "@/components/footer/footer";
@@ -5,8 +7,11 @@ import { Hero } from "@/components/hero/hero";
 import { Quote } from "@/components/quote/quote";
 import { Showcase } from "@/components/showcase/showcase";
 import { Testimonials } from "@/components/testimonials/testimonials";
+import { useRedirectWarning } from "@/lib/redirect";
 
 export default function Home() {
+  useRedirectWarning();
+
   return (
     <>
       <Hero />

--- a/src/lib/redirect.ts
+++ b/src/lib/redirect.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from "react";
 import { toast } from "sonner";
 
@@ -19,10 +21,12 @@ export function useRedirectWarning() {
     const redirectUrl = process.env.NEXT_PUBLIC_APP_REDIRECT_URL;
 
     if (!isLocalhost && !redirectUrl) {
-      toast.warning(
-        "NEXT_PUBLIC_APP_REDIRECT_URL is not set. Please set it in your environment variables for proper app redirects.",
-        { duration: 10000 },
-      );
+      setTimeout(() => {
+        toast.warning(
+          "NEXT_PUBLIC_APP_REDIRECT_URL is not set. Please set it in your environment variables for proper app redirects.",
+          { duration: 10000 },
+        );
+      }, 1000);
     }
   }, []);
 }


### PR DESCRIPTION
## Details

Adds a toast warning when first creating the project from the vercel template since we have the chicken and egg problem of not knowing the deployed URL for the universal link we can warn the user to add the missing env var