### PR TITLE
Fix deploy button in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Paddle Billing](https://www.paddle.com/solutions/web-stores?utm_source=dx&utm_medium=paddle-in-app-checkout-starter) is the developer-first merchant of record. We take care of payments, tax, subscriptions, and metrics with one unified API that does it all.
 
-This is a Next.js starter project for implementing a landing page, paywall and Paddle checkout on Web for an iOS app.
+This is a Next.js starter project for implementing marketing pages, including a pricing page, and Paddle checkout on Web for an iOS app.
 
 As of April 30, 2025, Apple's updated App Store rules allow app developers to use third-party payment processors like Paddle for in-app purchases. This starter shows you how to implement a web-based checkout that can be opened from iOS apps.
 
@@ -10,7 +10,7 @@ Even though you're redirecting users to Web to complete their purchase, **Apple 
 
 ## ⚡️ Instantly clone & deploy
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FPaddleHQ%2Fpaddle-mobile-web-payments-starter&env=APPLE_TEAM_ID,NEXT_PUBLIC_BUNDLE_IDENTIFIER,NEXT_PUBLIC_PADDLE_CLIENT_TOKEN,NEXT_PUBLIC_PADDLE_ENV)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FPaddleHQ%2Fpaddle-mobile-web-payments-starter&env=APPLE_TEAM_ID,NEXT_PUBLIC_BUNDLE_IDENTIFIER,NEXT_PUBLIC_APP_REDIRECT_URL,NEXT_PUBLIC_PADDLE_CLIENT_TOKEN,NEXT_PUBLIC_PADDLE_ENV)
 
 ## 🔦 About
 
@@ -61,4 +61,4 @@ Create a `.env.local` file based on `.env.example` with the following variables:
 - `NEXT_PUBLIC_PADDLE_CLIENT_TOKEN` - Your Paddle client token
 - `NEXT_PUBLIC_PADDLE_ENV` - Paddle environment (`sandbox` or `production`)
 
-For more detailed setup instructions, check out [Paddle's documentation on opening a checkout from iOS apps](https://developer.paddle.com/build/launch-ios-app-checkout).
+For more detailed setup instructions, check out [Paddle's documentation to deploy your starter app and launch a checkout from iOS](https://developer.paddle.com/build/nextjs-vercel-mobile-app-starter-kit).


### PR DESCRIPTION
## Details

Updates the Readme instructions to include the NEXT_PUBLIC_APP_REDIRECT_URL variable in the Vercel Deploy URL.